### PR TITLE
update go_router dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
 
   http: ^1.2.2
   provider: ^6.1.2
-  go_router: ^14.6.2  
+  go_router: ^16.1.0  
   package_info_plus: ^8.1.2
   material_symbols_icons: ^4.2815.1
   firebase_auth: ^5.3.4


### PR DESCRIPTION
This pull request updates a dependency version in the `pubspec.yaml` file to keep the project up to date.

Dependency updates:

* Upgraded the `go_router` package from version `14.6.2` to `16.1.0` in `pubspec.yaml` to incorporate the latest features and fixes.