### PR TITLE
update env from test to prod

### DIFF
--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -13,8 +13,8 @@ const bool loadDashboard = true;
 // const bool useDevOresvc = true;
 // use dev usersvc in release mode
 // const bool useDevUsersvc = true;
-const DeploymentTeir oreSvcTargetTier = DeploymentTeir.test;
-const DeploymentTeir userSvcTargetTier = DeploymentTeir.test;
+const DeploymentTeir oreSvcTargetTier = DeploymentTeir.prod;
+const DeploymentTeir userSvcTargetTier = DeploymentTeir.prod;
 
 // setting here is used to hard limit the scope of the portal
 // when deploying to different environment.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pag_ems_tp
 description: "Energy@Grid EMS Tenant Portal"
 publish_to: 'none'
-version: 0.6.2
+version: 0.6.3
 environment:
   sdk: '>=3.6.0'
 


### PR DESCRIPTION
This pull request updates the deployment configuration in `lib/app_config.dart` to target the production environment for both the ore service and user service, instead of the test environment.

- **Deployment Configuration Update:**
  * Changed `oreSvcTargetTier` and `userSvcTargetTier` constants to use `DeploymentTeir.prod` instead of `DeploymentTeir.test`, ensuring the application connects to production services.